### PR TITLE
Fix missing include of math.h

### DIFF
--- a/dirbrowser/randplayer.cpp
+++ b/dirbrowser/randplayer.cpp
@@ -18,6 +18,7 @@
 
 #include <QDebug>
 
+#include <math.h>
 #include <time.h>
 
 #include "randplayer.h"


### PR DESCRIPTION
Needed for round(). Otherwise build fails with GCC 6.x:
```
dirbrowser/randplayer.cpp: In member function ‘void RandPlayer::selectNextGroup()’:
dirbrowser/randplayer.cpp:86:39: error: ‘round’ was not declared in this scope
     int istart = vgstarts[round(fstart)];
```